### PR TITLE
link navigates to correct url. feature finished

### DIFF
--- a/client/src/components/groups/Group.js
+++ b/client/src/components/groups/Group.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Card, CardBody, CardImg, CardText, CardTitle, CardSubtitle, Row, Col } from "reactstrap";
+import { Link } from "react-router-dom";
 
 export default function Group({ group }) {
     const cardStyle = {
@@ -21,7 +22,9 @@ export default function Group({ group }) {
                 className="img-fluid"
             />
             <CardBody>
-                <CardTitle>{group.title}</CardTitle>
+                <Link to={`/group/${group.id}`}>
+                    <CardTitle>{group.title}</CardTitle>
+                </Link>
                 <CardText>{group.description}</CardText>
                 <Row>
                     <Col xs="4"> {/* Adjust the column size to your preference */}


### PR DESCRIPTION
## What?
Made Homepage group titles into clickable links that navigate to a group's details page
## Why?
This makes it easy for users to access their group's details page quickly and easily. Access to the details page will be vital for interaction with a group.
## How?
I used ReactStrap to turn the title into a link. I then used available state regarding the group id to point that link at the correct url
## Testing?
Checked multiple group title links. All worked as expected. Page is blank, but render is handled by another ticket