### PR TITLE
15 create a group form

### DIFF
--- a/Controllers/GroupController.cs
+++ b/Controllers/GroupController.cs
@@ -1,5 +1,7 @@
-﻿using HealthLink.Repositories;
+﻿using Azure;
+using HealthLink.Repositories;
 using Microsoft.AspNetCore.Mvc;
+using HealthLink.Models;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -43,8 +45,10 @@ namespace HealthLink.Controllers
 
         // POST api/<GroupController>
         [HttpPost]
-        public void Post([FromBody] string value)
+        public IActionResult Post(Group group)
         {
+            _groupRepository.Add(group);
+            return CreatedAtAction(nameof(GetAllGroups), new { id = group.Id }, group);
         }
 
         // PUT api/<GroupController>/5

--- a/Controllers/GroupController.cs
+++ b/Controllers/GroupController.cs
@@ -47,6 +47,10 @@ namespace HealthLink.Controllers
         [HttpPost]
         public IActionResult Post(Group group)
         {
+            if (group.LeadUserProfileId == null)
+            {
+                return BadRequest("LeadUserProfileId is required.");
+            }
             _groupRepository.Add(group);
             return CreatedAtAction(nameof(GetAllGroups), new { id = group.Id }, group);
         }

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -68,6 +68,20 @@ namespace HealthLink.Controllers
                 );
         }
 
+        [HttpPost("groupuser")]
+        public IActionResult AddUserToGroup(GroupUser groupUser)
+        {
+            if (groupUser == null)
+            {
+                return BadRequest("Invalid group user data.");
+            }
+
+            _userProfileRepository.AddGroupUser(groupUser);
+
+            return Ok(groupUser);
+        }
+
+
         //// PUT api/<UserProfileController>/5
         //[HttpPut("{id}")]
         //public void Put(int id, [FromBody] string value)

--- a/Repositories/GroupRepository.cs
+++ b/Repositories/GroupRepository.cs
@@ -81,6 +81,7 @@ namespace HealthLink.Repositories
 
         public void Add(Group group)
         {
+            group.CreatedDateTime = System.DateTime.Now;
             using (SqlConnection conn = Connection)
             {
                 conn.Open();
@@ -88,7 +89,8 @@ namespace HealthLink.Repositories
                 {
                     cmd.CommandText = @"INSERT INTO [Group]
                                         (LeaderUserProfileId, Title, [Description], ImageUrl, CreatedDateTime)
-                                        VALUES (@leaderUserProfileId, @title, @description, @imageUrl, @createdDateTime";
+                                        OUTPUT INSERTED.ID
+                                        VALUES (@leaderUserProfileId, @title, @description, @imageUrl, @createdDateTime)";
                     cmd.Parameters.AddWithValue("@leaderUserProfileId", group.LeadUserProfileId);
                     cmd.Parameters.AddWithValue("@title", group.Title);
                     cmd.Parameters.AddWithValue("@description", group.Description);

--- a/Repositories/GroupRepository.cs
+++ b/Repositories/GroupRepository.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using HealthLink.Models;
 using HealthLink.Utils;
 using System.Data;
+using Azure;
 
 namespace HealthLink.Repositories
 {
@@ -74,6 +75,26 @@ namespace HealthLink.Repositories
                         }
                         return groups;
                     }
+                }
+            }
+        }
+
+        public void Add(Group group)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO [Group]
+                                        (LeaderUserProfileId, Title, [Description], ImageUrl, CreatedDateTime)
+                                        VALUES (@leaderUserProfileId, @title, @description, @imageUrl, @createdDateTime";
+                    cmd.Parameters.AddWithValue("@leaderUserProfileId", group.LeadUserProfileId);
+                    cmd.Parameters.AddWithValue("@title", group.Title);
+                    cmd.Parameters.AddWithValue("@description", group.Description);
+                    cmd.Parameters.AddWithValue("@imageUrl", group.ImageUrl);
+                    cmd.Parameters.AddWithValue("@createdDateTime", group.CreatedDateTime);
+                    group.Id = (int)cmd.ExecuteScalar();
                 }
             }
         }

--- a/Repositories/IGroupRepository.cs
+++ b/Repositories/IGroupRepository.cs
@@ -8,5 +8,6 @@ namespace HealthLink.Repositories
         List<Group> GetAll();
         List<Group> GetAllActive();
         List<Group> GetAllGroupsByMemberId(int userId);
+        void Add(Group group);
     }
 }

--- a/Repositories/IUserProfileRepository.cs
+++ b/Repositories/IUserProfileRepository.cs
@@ -11,5 +11,7 @@ namespace HealthLink.Repositories
         UserProfile GetByEmail(string email);
         List<UserProfile> GetUsers();
         void Update(UserProfile userProfile);
+        void AddGroupUser(GroupUser groupUser);
+        //GroupUser GetGroupUserById(int groupUserId);
     }
 }

--- a/Repositories/UserProfileRepository.cs
+++ b/Repositories/UserProfileRepository.cs
@@ -155,6 +155,47 @@ namespace HealthLink.Repositories
             }
         }
 
+        //public GroupUser GetGroupUserById(int groupUserId)
+        //{
+        //    using (SqlConnection conn = Connection)
+        //    {
+        //        conn.Open();
+        //        using (SqlCommand cmd = conn.CreateCommand())
+        //        {
+        //            cmd.CommandText = @"SELECT Id, UserProfileId, GroupId
+        //                        FROM GroupUser
+        //                        WHERE Id = @groupUserId;";
+        //            cmd.Parameters.AddWithValue("@groupUserId", groupUserId);
+
+        //            using (SqlDataReader reader = cmd.ExecuteReader())
+        //            {
+        //                if (reader.Read())
+        //                {
+        //                    return NewGroupUser(reader);
+        //                }
+        //                return null; // Return null if the group user with the specified Id is not found
+        //            }
+        //        }
+        //    }
+        //}
+
+        public void AddGroupUser(GroupUser groupUser)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO [GroupUser] (GroupId, UserProfileId)
+                                        OUTPUT INSERTED.ID
+                                        VALUES (@groupId, @userProfileId)";
+                    cmd.Parameters.AddWithValue("@groupId", groupUser.GroupId);
+                    cmd.Parameters.AddWithValue("@userProfileId", groupUser.UserProfileId);
+                    groupUser.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+
         /*
         public UserProfile GetByFirebaseUserId(string firebaseUserId)
         {
@@ -189,5 +230,15 @@ namespace HealthLink.Repositories
                 ImageUrl = DbUtils.GetString(reader, "ImageUrl")
             };
         }
+
+        //private GroupUser NewGroupUser(SqlDataReader reader)
+        //{
+        //    return new GroupUser()
+        //    {
+        //        Id = DbUtils.GetInt(reader, "Id"),
+        //        UserProfileId = DbUtils.GetInt(reader, "UserProfileId"),
+        //        GroupId = DbUtils.GetInt(reader, "GroupId")
+        //    };
+        //}
     }
 }

--- a/client/src/components/ApplicationViews.js
+++ b/client/src/components/ApplicationViews.js
@@ -4,6 +4,7 @@ import Login from './auth/Login'
 import Register from './auth/Register'
 import MyGroupsList from './Homepage'
 import GroupsPage from './GroupsPage'
+import CreateGroupPage from './CreateAGroupPage'
 
 export default function ApplicationViews({ isLoggedIn }) {
 
@@ -18,6 +19,7 @@ export default function ApplicationViews({ isLoggedIn }) {
                 </Route>
                 <Route path="group">
                     <Route path="all" element={isLoggedIn ? <GroupsPage /> : <Navigate to="/login" />} />
+                    <Route path="create" element={isLoggedIn ? <CreateGroupPage /> : <Navigate to="/login" />} />
                 </Route>
                 <Route path="login" element={<Login />} />
                 <Route path="register" element={<Register />} />

--- a/client/src/components/CreateAGroupPage.js
+++ b/client/src/components/CreateAGroupPage.js
@@ -1,0 +1,52 @@
+import React from "react";
+import GroupForm from "./groups/GroupForm";
+import { createGroup } from "../modules/groupManager";
+import { addGroupUser } from "../modules/userProfileManager";
+import { useState, useEffect } from "react";
+
+export default function CreateGroupPage() {
+    const [leadUserProfileId, setLeadUserProfileId] = useState(null);
+
+    useEffect(() => {
+        // Get the leadUserProfileId from local storage on component mount
+        const localHealthLinkUser = localStorage.getItem("healthlink_user");
+        const HealthLinkUserObject = JSON.parse(localHealthLinkUser);
+        const userId = HealthLinkUserObject?.id || null;
+        setLeadUserProfileId(userId);
+    }, []);
+
+    const handleSubmit = (formData) => {
+        formData.leadUserProfileId = leadUserProfileId
+        // Call the API to create the group using formData
+        createGroup(formData)
+            .then((createdGroup) => {
+                // Call the API to create the groupUser with the created group's Id and the leader's Id
+                const groupUserFormData = {
+                    groupId: createdGroup.id,
+                    userProfileId: formData.leadUserProfileId,
+                };
+                addGroupUser(groupUserFormData)
+                    .then((createdGroupUser) => {
+                        console.log("GroupUser created successfully:", createdGroupUser);
+                        console.log("Group created successfully:", createdGroup);
+                        // Handle success
+                    })
+                    .catch((error) => {
+                        console.error("Error creating GroupUser:", error);
+                    });
+            })
+            .catch((error) => {
+                console.error("Error creating group:", error);
+            });
+    };
+
+    return (
+        <div>
+            <h1>Create a New Group</h1>
+            <GroupForm
+                group={null}
+                leadUserProfileId={leadUserProfileId}
+                onSubmit={handleSubmit} />
+        </div>
+    );
+}

--- a/client/src/components/groups/GroupForm.js
+++ b/client/src/components/groups/GroupForm.js
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+
+export default function GroupForm({ group, leadUserProfileId, onSubmit }) {
+    const [formData, setFormData] = useState({
+        title: "",
+        description: "",
+        imageUrl: "",
+        leadUserProfileId: leadUserProfileId || 0,
+    });
+
+    useEffect(() => {
+        setFormData((prevFormData) => ({
+            ...prevFormData,
+            leadUserProfileId: leadUserProfileId || 0,
+        }));
+
+        if (group) {
+            setFormData({
+                title: group.title || "",
+                description: group.description || "",
+                imageUrl: group.imageUrl || "",
+                leadUserProfileId: group.leadUserProfileId || leadUserProfileId,
+            });
+        }
+    }, [group]);
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setFormData({ ...formData, [name]: value });
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        onSubmit(formData);
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <div>
+                <label htmlFor="title">Title:</label>
+                <input
+                    type="text"
+                    name="title"
+                    id="title"
+                    value={formData.title}
+                    onChange={handleInputChange}
+                />
+            </div>
+            <div>
+                <label htmlFor="description">Description:</label>
+                <textarea
+                    name="description"
+                    id="description"
+                    value={formData.description}
+                    onChange={handleInputChange}
+                />
+            </div>
+            <div>
+                <label htmlFor="imageUrl">Image URL:</label>
+                <input
+                    type="text"
+                    name="imageUrl"
+                    id="imageUrl"
+                    value={formData.imageUrl}
+                    onChange={handleInputChange}
+                />
+            </div>
+            {/* Hidden input field for leadUserProfileId */}
+            <input type="hidden" name="leadUserProfileId" value={formData.leadUserProfileId} />
+            <button type="submit">{group ? "Update Group" : "Create Group"}</button>
+        </form>
+    );
+}

--- a/client/src/modules/groupManager.js
+++ b/client/src/modules/groupManager.js
@@ -37,3 +37,22 @@ export const getAllActiveGroups = () => {
         })
     })
 }
+
+export const createGroup = (group) => {
+    return getToken().then((token) => {
+        return fetch(baseAPIUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(group),
+        }).then((res) => {
+            if (res.ok) {
+                return res.json();
+            } else {
+                throw new Error("An unknown error occurred while creating the group.");
+            }
+        });
+    });
+};

--- a/client/src/modules/userProfileManager.js
+++ b/client/src/modules/userProfileManager.js
@@ -1,2 +1,22 @@
 import { getToken } from "./authManager"
 
+const baseAPIUrl = "/api/userprofile"
+
+export const addGroupUser = (groupUser) => {
+    return getToken().then((token) => {
+        return fetch(`${baseAPIUrl}/groupuser`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(groupUser),
+        }).then((res) => {
+            if (res.ok) {
+                return res.json();
+            } else {
+                throw new Error("An unknown error occurred while adding the user to the group.");
+            }
+        });
+    });
+};


### PR DESCRIPTION
## What?
Created a form for users to create a new group.
## Why?
This feature will allow the user community to grow. Users can create smaller or larger groups for more intimate or egalitarian groups. These changes are pursuant to the user story found in issue ticket #15 
## How?
I created API endpoints to create a new group and establish a connection between the creator and the group. I then created a form that gathers user data to create the group and group/user objects to send to the database. After that, I connected the two ends.
## Testing?
I successfully created a group and was automatically established as the leader and a member.