### PR TITLE
9 challenge details page render

### DIFF
--- a/Controllers/ChallengeController.cs
+++ b/Controllers/ChallengeController.cs
@@ -17,9 +17,9 @@ namespace HealthLink.Controllers
 
         // GET api/<ChallengeController>/5
         [HttpGet("{id}")]
-        public string Get(int id)
+        public IActionResult Get(int id)
         {
-            return "value";
+            return Ok();
         }
 
         // POST api/<ChallengeController>

--- a/Controllers/ChallengeController.cs
+++ b/Controllers/ChallengeController.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using HealthLink.Repositories;
+using HealthLink.Models;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -8,6 +10,12 @@ namespace HealthLink.Controllers
     [ApiController]
     public class ChallengeController : ControllerBase
     {
+        private IChallengeRepository _challengeRepository;
+
+        public ChallengeController(IChallengeRepository challengeRepository)
+        {
+            _challengeRepository = challengeRepository;
+        }
         // GET: api/<ChallengeController>
         [HttpGet]
         public IActionResult Get()
@@ -17,9 +25,14 @@ namespace HealthLink.Controllers
 
         // GET api/<ChallengeController>/5
         [HttpGet("{id}")]
-        public IActionResult Get(int id)
+        public IActionResult GetChallengeById(int id)
         {
-            return Ok();
+            Challenge challenge = _challengeRepository.GetChallengeById(id);
+            if (challenge == null)
+            {
+                return NotFound();
+            }
+            return Ok(challenge);
         }
 
         // POST api/<ChallengeController>

--- a/Repositories/ChallengeRepository.cs
+++ b/Repositories/ChallengeRepository.cs
@@ -42,6 +42,34 @@ namespace HealthLink.Repositories
                 }
             }
         }
+
+        public Challenge GetChallengeById(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT Id, CreatedDateTime, EndDate, Title, [Description], GroupId FROM Challenge
+                                        WHERE Id = @id";
+                    cmd.Parameters.AddWithValue("@id", id);
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                    {
+                        if (reader.Read())
+                        {
+                            Challenge challenge = new Challenge()
+                            {
+
+                            };
+                            return challenge;
+                        }
+                        return null;
+                    }
+                }
+            }
+        }
+
+
     }
 
 }

--- a/Repositories/ChallengeRepository.cs
+++ b/Repositories/ChallengeRepository.cs
@@ -18,10 +18,12 @@ namespace HealthLink.Repositories
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"SELECT Id AS ChallengeId,
-                                           GroupId,
-                                           Title AS ChallengeTitle,
-                                           Description AS ChallengeDescription
-                                    FROM [Challenge]
+                                        GroupId,
+                                        Title AS ChallengeTitle,
+                                        [Description]AS ChallengeDescription,
+                                        CreatedDateTime AS ChallengeStartDate,
+                                        EndDate AS ChallengeEndDate
+                                        FROM [Challenge] 
                                     WHERE GroupId = @groupId";
                     cmd.Parameters.AddWithValue("@groupId", groupId);
                     using (SqlDataReader reader = cmd.ExecuteReader())
@@ -34,7 +36,9 @@ namespace HealthLink.Repositories
                                 Id = DbUtils.GetInt(reader, "ChallengeId"),
                                 GroupId = DbUtils.GetInt(reader, "GroupId"),
                                 Title = DbUtils.GetString(reader, "ChallengeTitle"),
-                                Description = DbUtils.GetString(reader, "ChallengeDescription")
+                                Description = DbUtils.GetString(reader, "ChallengeDescription"),
+                                CreatedDateTime = DbUtils.GetDateTime(reader, "ChallengeStartDate"),
+                                EndDateTime = DbUtils.GetDateTime(reader, "ChallengeEndDate")
                             });
                         }
                         return challenges;
@@ -50,8 +54,14 @@ namespace HealthLink.Repositories
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"SELECT Id, CreatedDateTime, EndDate, Title, [Description], GroupId FROM Challenge
-                                        WHERE Id = @id";
+                    cmd.CommandText = @"SELECT Id AS ChallengeId,
+                                        GroupId,
+                                        Title AS ChallengeTitle,
+                                        [Description] AS ChallengeDescription,
+                                        CreatedDateTime AS ChallengeStartDate,
+                                        EndDate AS ChallengeEndDate
+                                        FROM [Challenge] 
+                                    WHERE Id = @id";
                     cmd.Parameters.AddWithValue("@id", id);
                     using (SqlDataReader reader = cmd.ExecuteReader())
                     {
@@ -59,7 +69,12 @@ namespace HealthLink.Repositories
                         {
                             Challenge challenge = new Challenge()
                             {
-
+                                Id = DbUtils.GetInt(reader, "ChallengeId"),
+                                GroupId = DbUtils.GetInt(reader, "GroupId"),
+                                Title = DbUtils.GetString(reader, "ChallengeTitle"),
+                                Description = DbUtils.GetString(reader, "ChallengeDescription"),
+                                CreatedDateTime = DbUtils.GetDateTime(reader, "ChallengeStartDate"),
+                                EndDateTime = DbUtils.GetDateTime(reader, "ChallengeEndDate")
                             };
                             return challenge;
                         }

--- a/Repositories/GroupRepository.cs
+++ b/Repositories/GroupRepository.cs
@@ -31,14 +31,6 @@ namespace HealthLink.Repositories
                                 group = NewGroup(reader);
                                 groups.Add(group);
                             }
-                            else
-                            {
-                                Challenge challenge = FindChallengeInList(group.Challenges, reader);
-                                if (challenge == null)
-                                {
-                                    group.Challenges.Add(NewChallenge(reader)); // Add the challenge to the list
-                                }
-                            }
                         }
                         return groups;
                     }
@@ -64,14 +56,6 @@ namespace HealthLink.Repositories
                             {
                                 group = NewGroup(reader);
                                 groups.Add(group);
-                            }
-                            else
-                            {
-                                Challenge challenge = FindChallengeInList(group.Challenges, reader);
-                                if (challenge == null)
-                                {
-                                    group.Challenges.Add(NewChallenge(reader)); // Add the challenge to the list
-                                }
                             }
                         }
                         return groups;
@@ -101,14 +85,6 @@ namespace HealthLink.Repositories
                             {
                                 group = NewGroup(reader);
                                 groups.Add(group);
-                            }
-                            else
-                            {
-                                Challenge challenge = FindChallengeInList(group.Challenges, reader);
-                                if (challenge == null)
-                                {
-                                    group.Challenges.Add(NewChallenge(reader)); // Add the challenge to the list
-                                }
                             }
                         }
                         return groups;
@@ -201,17 +177,10 @@ namespace HealthLink.Repositories
                                         l.Email AS LeaderUserProfileEmail,
                                         l.ImageUrl AS LeaderUserProfileImageUrl,
                                         l.CreatedDateTime AS LeaderUserProfileCreatedDateTime,
-                                        c.Id AS ChallengeId,
-                                        c.CreatedDateTime AS ChallengeCreatedDateTime,
-                                        c.EndDate AS ChallengeEndDateTime,
-                                        c.Title AS ChallengeTitle,
-                                        c.Description AS ChallengeDescription,
-                                        c.GroupId AS ChallengeGroupId,
                                         gu.Id AS GroupUserId,
                                         gu.UserProfileId AS GroupUserUserProfileId
                                     FROM [Group] g
                                     LEFT JOIN [UserProfile] l ON g.LeaderUserProfileId = l.Id
-                                    LEFT JOIN [Challenge] c ON g.Id = c.GroupId
                                     LEFT JOIN [GroupUser] gu ON g.Id = gu.GroupId";
 
 
@@ -230,17 +199,10 @@ namespace HealthLink.Repositories
                                                 l.Email AS LeaderUserProfileEmail,
                                                 l.ImageUrl AS LeaderUserProfileImageUrl,
                                                 l.CreatedDateTime AS LeaderUserProfileCreatedDateTime,
-                                                c.Id AS ChallengeId,
-                                                c.CreatedDateTime AS ChallengeCreatedDateTime,
-                                                c.EndDate AS ChallengeEndDateTime,
-                                                c.Title AS ChallengeTitle,
-                                                c.Description AS ChallengeDescription,
-                                                c.GroupId AS ChallengeGroupId,
                                                 gu.Id AS GroupUserId,
                                                 gu.UserProfileId AS GroupUserUserProfileId
                                             FROM [Group] g
                                             INNER JOIN [UserProfile] l ON g.LeaderUserProfileId = l.Id
-                                            LEFT JOIN [Challenge] c ON g.Id = c.GroupId
                                             LEFT JOIN [GroupUser] gu ON g.Id = gu.GroupId";
 
         private Group FindGroupInList(List<Group> groups, SqlDataReader reader)
@@ -287,27 +249,7 @@ namespace HealthLink.Repositories
                 group.LeadUserProfile = null;
             }
 
-            if (!reader.IsDBNull(reader.GetOrdinal("ChallengeId")))
-            {
-                
-            }
-
             return group;
-        }
-
-        private Challenge NewChallenge(SqlDataReader reader)
-        {
-            Challenge challenge = new Challenge()
-            {
-                Id = DbUtils.GetInt(reader, "ChallengeId"),
-                CreatedDateTime = DbUtils.GetDateTime(reader, "ChallengeCreatedDateTime"),
-                EndDateTime = DbUtils.GetDateTime(reader, "ChallengeEndDateTime"),
-                Title = DbUtils.GetString(reader, "ChallengeTitle"),
-                Description = DbUtils.GetString(reader, "ChallengeDescription"),
-                GroupId = DbUtils.GetInt(reader, "ChallengeGroupId")
-            };
-
-            return challenge;
         }
     }
 }

--- a/Repositories/IChallengeRepository.cs
+++ b/Repositories/IChallengeRepository.cs
@@ -6,5 +6,6 @@ namespace HealthLink.Repositories
     public interface IChallengeRepository
     {
         List<Challenge> GetChallengesByGroupId(int groupId);
+        Challenge GetChallengeById(int id);
     }
 }

--- a/client/src/components/ApplicationViews.js
+++ b/client/src/components/ApplicationViews.js
@@ -7,6 +7,7 @@ import GroupsPage from './GroupsPage'
 import CreateGroupPage from './CreateAGroupPage'
 import GroupDetailsPage from './GroupDetailsPage'
 import EditAGroupPage from './EditAGroupPage'
+import ChallengeDetailsPage from './ChallengeDetailsPage'
 
 export default function ApplicationViews({ isLoggedIn }) {
 
@@ -24,6 +25,9 @@ export default function ApplicationViews({ isLoggedIn }) {
                     <Route path="create" element={isLoggedIn ? <CreateGroupPage /> : <Navigate to="/login" />} />
                     <Route path=":id" element={isLoggedIn ? <GroupDetailsPage /> : <Navigate to="/login" />} />
                     <Route path=":id/edit" element={isLoggedIn ? <EditAGroupPage /> : <Navigate to="/login" />} />
+                </Route>
+                <Route path="challenge">
+                    <Route path=":id" element={isLoggedIn ? <ChallengeDetailsPage /> : <Navigate to="/login" />} />
                 </Route>
                 <Route path="login" element={<Login />} />
                 <Route path="register" element={<Register />} />

--- a/client/src/components/ChallengeDetailsPage.js
+++ b/client/src/components/ChallengeDetailsPage.js
@@ -8,7 +8,7 @@ export default function ChallengeDetailsPage() {
     const { id } = useParams();
     const [challenge, setChallenge] = useState([]);
     const [group, setGroup] = useState([]);
-    const [isUserMember, setIsUserMember] = useState(false);
+    const [isLeader, setIsLeader] = useState(false);
 
     useEffect(() => {
         // Fetch challenge details
@@ -25,8 +25,11 @@ export default function ChallengeDetailsPage() {
                 .then((data) => {
                     setGroup(data)
                     const currentUser = getCurrentUserFromLocalStorage();
-                    const isMember = data.members.some((member) => member.userProfileId === currentUser.id);
-                    setIsUserMember(isMember);
+                    let leaderStatus = false;
+                    if (currentUser.id === data.leadUserProfileId) {
+                        leaderStatus = true;
+                    }
+                    setIsLeader(leaderStatus);
                 })
                 .catch((error) => console.error(error));
         }
@@ -43,7 +46,7 @@ export default function ChallengeDetailsPage() {
         return (
             <div>
                 <h2>{challenge.title}</h2>
-                {isBeforeEndDate && isUserMember && (
+                {isBeforeEndDate && isLeader && (
                     <Link to={`/challenge/${id}/edit`}>Edit</Link>
                 )}
                 <p>{challenge.description}</p>

--- a/client/src/components/ChallengeDetailsPage.js
+++ b/client/src/components/ChallengeDetailsPage.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { getChallengeById } from '../modules/challengeManager';
+import { getGroupById } from '../modules/groupManager';
+
+export default function ChallengeDetailsPage() {
+    const { id } = useParams();
+    const [challenge, setChallenge] = useState([]);
+    const [group, setGroup] = useState([]);
+
+    useEffect(() => {
+        // Fetch challenge details
+        console.log(id)
+        getChallengeById(id)
+            .then((data) => setChallenge(data))
+            .catch((error) => console.error(error));
+    }, [id]);
+
+    useEffect(() => {
+        // Fetch associated group details when the challenge state is updated
+        if (challenge && challenge.groupId) {
+            getGroupById(challenge.groupId)
+                .then((data) => setGroup(data))
+                .catch((error) => console.error(error));
+        }
+    }, [challenge]);
+
+    const renderChallengeDetails = () => {
+        if (!challenge) {
+            return <p>Loading challenge details...</p>;
+        }
+
+        const currentDate = new Date();
+        const isBeforeEndDate = currentDate < new Date(challenge.endDateTime);
+
+        return (
+            <div>
+                <h2>{challenge.title}</h2>
+                <p>{challenge.description}</p>
+                <p>Start Date: {new Date(challenge.createdDateTime).toLocaleDateString()}</p>
+                <p>End Date: {new Date(challenge.endDateTime).toLocaleDateString()}</p>
+
+                {group && (
+                    <p>
+                        Associated Group:{' '}
+                        <Link to={`/group/${group.id}`}>{group.title}</Link>
+                    </p>
+                )}
+
+                <h3>{isBeforeEndDate ? 'Member Progress' : 'Member Results'}</h3>
+                {/* Display member progress or member results here */}
+            </div>
+        );
+    };
+
+    return (
+        <div>
+            <h1>Challenge Details</h1>
+            {renderChallengeDetails()}
+        </div>
+    );
+};

--- a/client/src/components/ChallengeDetailsPage.js
+++ b/client/src/components/ChallengeDetailsPage.js
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { getChallengeById } from '../modules/challengeManager';
 import { getGroupById } from '../modules/groupManager';
+import { getCurrentUserFromLocalStorage } from '../modules/userProfileManager';
 
 export default function ChallengeDetailsPage() {
     const { id } = useParams();
     const [challenge, setChallenge] = useState([]);
     const [group, setGroup] = useState([]);
+    const [isUserMember, setIsUserMember] = useState(false);
 
     useEffect(() => {
         // Fetch challenge details
@@ -20,7 +22,12 @@ export default function ChallengeDetailsPage() {
         // Fetch associated group details when the challenge state is updated
         if (challenge && challenge.groupId) {
             getGroupById(challenge.groupId)
-                .then((data) => setGroup(data))
+                .then((data) => {
+                    setGroup(data)
+                    const currentUser = getCurrentUserFromLocalStorage();
+                    const isMember = data.members.some((member) => member.userProfileId === currentUser.id);
+                    setIsUserMember(isMember);
+                })
                 .catch((error) => console.error(error));
         }
     }, [challenge]);
@@ -36,6 +43,9 @@ export default function ChallengeDetailsPage() {
         return (
             <div>
                 <h2>{challenge.title}</h2>
+                {isBeforeEndDate && isUserMember && (
+                    <Link to={`/challenge/${id}/edit`}>Edit</Link>
+                )}
                 <p>{challenge.description}</p>
                 <p>Start Date: {new Date(challenge.createdDateTime).toLocaleDateString()}</p>
                 <p>End Date: {new Date(challenge.endDateTime).toLocaleDateString()}</p>

--- a/client/src/modules/challengeManager.js
+++ b/client/src/modules/challengeManager.js
@@ -1,0 +1,20 @@
+import { getToken } from "./authManager";
+
+const baseAPIUrl = "/api/challenge"
+
+export const getChallengeById = (challengeId) => {
+    return getToken().then((token) => {
+        return fetch(`${baseAPIUrl}/${challengeId}`, {
+            method: "GET",
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        }).then((res) => {
+            if (res.ok) {
+                return res.json();
+            } else {
+                throw new Error("An unknown error occurred while trying to retrieve the challenge.");
+            }
+        });
+    });
+};


### PR DESCRIPTION
## What?
I created a challenge details page that lists the information about a specific challenge, including a link to the associated group page. There is also an "edit" button for the challenge. That button only appear before a challenges end date and only for members of the associated group.
## Why?
This page will allow users to learn more about challenges and view/edit challenge progress. It will also allow leaders to edit the challenges.
## How?
I wrote a new API endpoint to retrieve a challenge by id. I used the previous endpoint to retrieve a group by id. I wrote code to conditionally render the Member Results/Member Progress title and the edit button. 
## Testing?
I viewed several challenge pages with no issue. I verified the conditional rendering of the edit button by viewing several groups as a member, nonmember, and leader. Worked as expected