### PR TITLE
refactored a few exports to follow the same format as other exports

### DIFF
--- a/client/src/components/challenges/CreateAChallengePage.js
+++ b/client/src/components/challenges/CreateAChallengePage.js
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { getCurrentUserFromLocalStorage } from '../../modules/userProfileManager';
 import { getMyGroups } from '../../modules/groupManager';
 
-const CreateAChallengePage = () => {
+export default function CreateAChallengePage() {
     const [challenge, setChallenge] = useState({
         title: '',
         description: '',
@@ -75,5 +75,3 @@ const CreateAChallengePage = () => {
         </div>
     );
 };
-
-export default CreateAChallengePage;

--- a/client/src/components/challenges/EditAChallengePage.js
+++ b/client/src/components/challenges/EditAChallengePage.js
@@ -4,7 +4,7 @@ import ChallengeForm from './ChallengeForm';
 import { getChallengeById, updateChallenge } from '../../modules/challengeManager';
 import { getGroupById } from '../../modules/groupManager';
 
-const EditChallengePage = () => {
+export default function EditChallengePage() {
     const { challengeId } = useParams();
     const [challenge, setChallenge] = useState(null);
     const [groupOption, setGroupOption] = useState(null);
@@ -77,5 +77,3 @@ const EditChallengePage = () => {
         </div>
     );
 };
-
-export default EditChallengePage;

--- a/client/src/components/results/MemberResultsCard.js
+++ b/client/src/components/results/MemberResultsCard.js
@@ -3,7 +3,7 @@ import { Card, CardBody, CardTitle, CardText, Button } from 'reactstrap';
 import { deleteResult } from '../../modules/resultManager';
 import { useNavigate } from 'react-router-dom';
 
-const MemberResultCard = ({ result, currentUser, isBeforeEndDate }) => {
+export default function MemberResultCard({ result, currentUser, isBeforeEndDate }) {
     const navigate = useNavigate();
     const handleEditClick = () => { navigate(`/challenge/result/${result.id}`) }
     const handleDeleteClick = () => {
@@ -35,5 +35,3 @@ const MemberResultCard = ({ result, currentUser, isBeforeEndDate }) => {
         </Card>
     );
 };
-
-export default MemberResultCard;

--- a/client/src/components/results/ResultCreatePage.js
+++ b/client/src/components/results/ResultCreatePage.js
@@ -7,7 +7,7 @@ import { getChallengeById } from '../../modules/challengeManager';
 import { getGroupUserByBothIds } from '../../modules/userProfileManager';
 import { Button } from 'reactstrap'
 
-const ResultCreatePage = () => {
+export default function ResultCreatePage() {
     const { challengeId } = useParams();
     const [content, setContent] = useState('');
     const [groupUserId, setGroupUserId] = useState(0);
@@ -64,5 +64,3 @@ const ResultCreatePage = () => {
         </div>
     );
 };
-
-export default ResultCreatePage;

--- a/client/src/components/results/ResultEditPage.js
+++ b/client/src/components/results/ResultEditPage.js
@@ -4,7 +4,7 @@ import ResultForm from './ResultForm';
 import { getResultById, updateResult } from '../../modules/resultManager';
 import { Button } from 'reactstrap';
 
-const ResultEditPage = () => {
+export default function ResultEditPage() {
     const { resultId } = useParams();
     const [retrievedResult, setResult] = useState(null);
 
@@ -46,5 +46,3 @@ const ResultEditPage = () => {
         </div>
     );
 };
-
-export default ResultEditPage;

--- a/client/src/components/results/ResultForm.js
+++ b/client/src/components/results/ResultForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ResultForm = ({ result, onContentChange }) => {
+export default function ResultForm({ result, onContentChange }) {
     return (
         <div>
             <label htmlFor="content">Content:</label>
@@ -13,5 +13,3 @@ const ResultForm = ({ result, onContentChange }) => {
         </div>
     );
 };
-
-export default ResultForm;


### PR DESCRIPTION
## What?
I refactored a handful of function exports to follow the same format as the majority. For example, instead of "const functionName = () => {} 
export default functionName" I used the format "export default function functionName(){}"
## Why?
This formatting is more concise. Changing the exports to match the same format makes my code slightly more legible as well.